### PR TITLE
Fix authentication to use Amazon CSRF tokens

### DIFF
--- a/cloudplaya/client.py
+++ b/cloudplaya/client.py
@@ -138,7 +138,7 @@ class Client(object):
                     csrf_tokens = config['CSRFTokenConfig']
                     auth_vars['csrf_rnd'] = csrf_tokens['csrf_rnd']
                     auth_vars['csrf_token'] = csrf_tokens['csrf_token']
-                    auth_vars['csrf_ts'] = csrf_tokens['CSRFTokenConfig']['csrf_ts']
+                    auth_vars['csrf_ts'] = csrf_tokens['csrf_ts']
                 except KeyError, e:
                     logging.error("Unable to locate key %s in "
                                   "amznMusic.appConfig" % e)

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import getpass
 import os
 import sys
 from optparse import OptionGroup, OptionParser
@@ -35,7 +36,8 @@ class Authenticate(Command):
 
     def run(self):
         try:
-            if self.client.authenticate(self.options.username):
+            password = getpass.getpass()
+            if self.client.authenticate(self.options.username, password):
                 print 'Authenticated successfully.'
             else:
                 sys.stderr.write('Authentication failed.\n')

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -32,13 +32,10 @@ class Authenticate(Command):
     def add_options(self, parser):
         parser.add_option('--username', default=None,
                           help='the username to log in as')
-        parser.add_option('--password', default='%(name)s',
-                          help='the password for your user')
 
     def run(self):
         try:
-            if self.client.authenticate(self.options.username,
-                                        self.options.password):
+            if self.client.authenticate(self.options.username):
                 print 'Authenticated successfully.'
             else:
                 sys.stderr.write('Authentication failed.\n')
@@ -290,8 +287,7 @@ def main():
     if not client.authenticated and command != COMMANDS['authenticate']:
         sys.stderr.write('You must authenticate before you can use '
                          'cloudplaya:\n')
-        sys.stderr.write('    $ cloud-playa authenticate --username <username> '
-                         '--password <password>\n')
+        sys.stderr.write('    $ cloudplaya authenticate --username <username>\n')
         sys.exit(2)
 
     command.client = client
@@ -299,3 +295,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
Amazon's authentication scheme has changed.  I've updated cloudplaya with the following fixes:
- Dropped cp_token in lieu of csrf_rnd, csrf_token, and csrf_ts
- Use safer getpass instead of using password parameter
- Use AUTH_URL to get Amazon's OpenID page for the signin form, rather than the old Cloudplayer signin form.
