### PR TITLE
Authentication fix + download-all

### DIFF
--- a/cloudplaya/client.py
+++ b/cloudplaya/client.py
@@ -138,7 +138,7 @@ class Client(object):
                     csrf_tokens = config['CSRFTokenConfig']
                     auth_vars['csrf_rnd'] = csrf_tokens['csrf_rnd']
                     auth_vars['csrf_token'] = csrf_tokens['csrf_token']
-                    auth_vars['csrf_ts'] = csrf_tokens['CSRFTokenConfig']['csrf_ts']
+                    auth_vars['csrf_ts'] = csrf_tokens['csrf_ts']
                 except KeyError, e:
                     logging.error("Unable to locate key %s in "
                                   "amznMusic.appConfig" % e)

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -104,7 +104,11 @@ class DownloadAll(Command):
                 os.makedirs(os.path.dirname(out_path))
 
             print 'Downloading %s ...' % out_path
-            if not self.options.dry_run:
+            if self.options.dry_run:
+                print '  Dry run. Not actually downloading.'
+            elif os.path.getsize(out_path) > 0:
+                print 'file already exists. Skipping: %s' % out_path
+            else:
                 r = requests.get(url)
 
                 try:

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import getpass
 import os
 import sys
 from optparse import OptionGroup, OptionParser
@@ -35,7 +36,8 @@ class Authenticate(Command):
 
     def run(self):
         try:
-            if self.client.authenticate(self.options.username):
+            password = getpass.getpass()
+            if self.client.authenticate(self.options.username, password):
                 print 'Authenticated successfully.'
             else:
                 sys.stderr.write('Authentication failed.\n')

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -32,13 +32,10 @@ class Authenticate(Command):
     def add_options(self, parser):
         parser.add_option('--username', default=None,
                           help='the username to log in as')
-        parser.add_option('--password', default='%(name)s',
-                          help='the password for your user')
 
     def run(self):
         try:
-            if self.client.authenticate(self.options.username,
-                                        self.options.password):
+            if self.client.authenticate(self.options.username):
                 print 'Authenticated successfully.'
             else:
                 sys.stderr.write('Authentication failed.\n')
@@ -290,8 +287,7 @@ def main():
     if not client.authenticated and command != COMMANDS['authenticate']:
         sys.stderr.write('You must authenticate before you can use '
                          'cloudplaya:\n')
-        sys.stderr.write('    $ cloud-playa authenticate --username <username> '
-                         '--password <password>\n')
+        sys.stderr.write('    $ cloudplaya authenticate --username <username>\n')
         sys.exit(2)
 
     command.client = client
@@ -299,3 +295,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
Hi chipx86, the following changes roll up what @tgross has done, make the requests a little more resilient to errors, and add a "download-all" command to pull an entire library. Four interesting changes:
- `download-all` is a new command. I think that's fairly easy to understand.
- `--dry-run` keeps `download-all` from actually running, which can take a long time.
- `--start-at-artist` uses the `GREATER_THAN_OR_EQUAL` search operator to start midway into a list of artists.
- `download-all` skips existing files.

Here's an example from inside the cloudplaya directory:

```
python main.py download-all --dry-run --out-directory=/tmp/ --start-at-artist "Fartbarf"
```
