### PR TITLE
Added ez_setup to install requirements 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name=PACKAGE_NAME,
       install_requires=[
           'mechanize>=0.2.5',
           'requests>=0.13.2',
+          'ez_setup',
       ],
       maintainer='Christian Hammond',
       maintainer_email='chipx86@chipx86.com',


### PR DESCRIPTION
Without ez_setup 'sudo pip install cloudplaya' fails with 'ImportError: No module named ez_setup'
