### PR TITLE
Re-enable access to song URLs and device authorization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Authenticating
 You will need to first authenticate with Amazon Cloud Player. This will store a
 .cloudplayasession file and a .cloudplayacookies file in your home directory
 containing some session information. Note that it's possible you may have to
-repeat this on occasion. Also, note that if you delete the .cloudplayacookies
+repeat this on occasion.
 
 To authenticate, run::
 
@@ -44,7 +44,7 @@ To authorize, run::
 Replace ``<device_name>`` with the name that you would like cloudplaya to
 appear as in Amazon's authorized device list.
 
-Note that if you delete the .cloudplayacookies file, you will loose the Amazon
+Note that if you delete the .cloudplayacookies file, you will lose the Amazon
 cookie that estabilishes the uniqe device id for cloudplaya, and subsequent
 reauthentication of cloudplaya will result in the assignment of a new device
 id, using up another of your ten authorized device slots.

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,10 @@ To install cloudplaya, just run::
 Authenticating
 --------------
 
-You will need to first authenticate with Amazon Cloud Player. This will store
-.cloudplayarc file in your home directory containing some session information.
-Note that it's possible you may have to repeat this on occasion.
+You will need to first authenticate with Amazon Cloud Player. This will store a
+.cloudplayasession file and a .cloudplayacookies file in your home directory
+containing some session information. Note that it's possible you may have to
+repeat this on occasion. Also, note that if you delete the .cloudplayacookies
 
 To authenticate, run::
 
@@ -28,8 +29,27 @@ To authenticate, run::
 Replace ``<email_address>`` and ``<password>`` with your Amazon account
 e-mail and password above.
 
-You're then ready to use cloudplaya!
+You're then ready to authorize cloudplaya.
 
+Authorizing
+-----------
+
+In addition to authenticating, you also need to add cloudplaya as an authorized
+device on your Cloud Player account.
+
+To authorize, run::
+
+    $ cloudplaya authorize --devname <device_name>
+
+Replace ``<device_name>`` with the name that you would like cloudplaya to
+appear as in Amazon's authorized device list.
+
+Note that if you delete the .cloudplayacookies file, you will loose the Amazon
+cookie that estabilishes the uniqe device id for cloudplaya, and subsequent
+reauthentication of cloudplaya will result in the assignment of a new device
+id, using up another of your ten authorized device slots.
+
+You're then ready to use cloudplaya!
 
 Commands
 --------

--- a/cloudplaya/client.py
+++ b/cloudplaya/client.py
@@ -20,17 +20,19 @@ class RequestError(Exception):
         super(Exception, self).__init__(msg)
         self.code = code
 
+
 class DeviceNotAuthorizedError(Exception):
     def __init__(self, msg):
         super(Exception, self).__init__(msg)
+
 
 class Client(object):
     AUTH_URL = 'https://www.amazon.com/ap/signin?openid.assoc_handle=usflex&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fdmusic%2Fmp3%2Fplayer%3Fie%3DUTF8%26requestedView%3Dsongs'
     PLAYER_URL = 'https://www.amazon.com/gp/dmusic/mp3/player'
     API_URL = {
-        'V1' : 'https://www.amazon.com/cirrus/',
-        'V2' : 'https://www.amazon.com/cirrus/2011-06-01/'
-        }
+        'V1': 'https://www.amazon.com/cirrus/',
+        'V2': 'https://www.amazon.com/cirrus/2011-06-01/'
+    }
 
     APPCONFIG_RE = re.compile('\s*amznMusic.appConfig\s*=\s*({.*});$')
 
@@ -174,45 +176,55 @@ class Client(object):
     def authorize(self, device_name):
         if not self.check_device_authorization():
             avail_result = self.get_device_authorization_availability()
+
             if avail_result['deviceAuthorizationAvailability'] == u'AVAILABLE':
                 auth_result = self.authorize_device(device_name)
+
                 if self.check_device_authorization():
                     return True
+
         return False
 
     def get_device_authorizations_list(self):
-        result = self._get(operation='listDeviceAuthorizations',data={},version='V2')
+        result = self._get(operation='listDeviceAuthorizations',
+                           data={},
+                           version='V2')
         auth_result = self._get_payload_data(result, [
             'listDeviceAuthorizationsResponse',
             'listDeviceAuthorizationsResult',
-            ])
+        ])
         return auth_result
 
     def get_device_authorization_availability(self):
-        result = self._get( operation='getDeviceAuthorizationAvailability',
-                            data={'deviceId':self.device_id,'deviceType':self.device_type},
-                            version='V2')
+        result = self._get(operation='getDeviceAuthorizationAvailability',
+                           data={'deviceId': self.device_id,
+                                 'deviceType': self.device_type},
+                           version='V2')
         avail_result = self._get_payload_data(result, [
             'getDeviceAuthorizationAvailabilityResponse',
             'getDeviceAuthorizationAvailabilityResult',
-            ])
+        ])
         return avail_result
 
-    def authorize_device(self,device_name):
-        result = self._get( operation='authorizeDevice',
-                            data={'deviceName':device_name},
-                            version='V2')
+    def authorize_device(self, device_name):
+        result = self._get(operation='authorizeDevice',
+                           data={'deviceName': device_name},
+                           version='V2')
         return result
 
     def check_device_authorization(self, auth_result=None):
         if not auth_result:
             auth_result = self.get_device_authorizations_list()
+
         try:
             for dev_auth in auth_result['deviceAuthorizations']:
-                if dev_auth['deviceId'] == self.device_id and dev_auth['deviceType'] == self.device_type and dev_auth['authorizationState'] == "ACTIVE":
+                if (dev_auth['deviceId'] == self.device_id and
+                        dev_auth['deviceType'] == self.device_type and
+                        dev_auth['authorizationState'] == "ACTIVE"):
                     return True
         except KeyError, e:
             pass
+
         return False
 
     def get_track_list(self, album):
@@ -250,7 +262,8 @@ class Client(object):
 
     def get_song_stream_urls(self, song_ids):
         if not self.authorized:
-            raise DeviceNotAuthorizedError("Device must be authorized before call to get_song_stream_urls()")
+            raise DeviceNotAuthorizedError("Device must be authorized before " \
+                                           "call to get_song_stream_urls()")
 
         data = {}
 
@@ -377,13 +390,13 @@ class Client(object):
             'customerInfo.deviceId': self.device_id,
             'customerInfo.deviceType': self.device_type,
         })
-        
-        #Version 2.0.1 of requests claims that you can supply a CookieJar object
-        #for the the cookies parameter of requests.request(), however, in version
-        #2.0.1 it has code in Session.request() (which is what is called by
-        #requests.request()) that treats the cookies parameter as a dict and will
-        #fail if a CookieJar (lacking __getitem__()) is supplied...
-        #so, unpack the CookieJar to a dict for now...
+
+        # Version 2.0.1 of requests claims that you can supply a CookieJar
+        # object for the the cookies parameter of requests.request(), however,
+        # in version 2.0.1 it has code in Session.request() (which is what is
+        # called by requests.request()) that treats the cookies parameter as a
+        # dict and will fail if a CookieJar (lacking __getitem__()) is
+        # supplied... so, unpack the CookieJar to a dict for now...
         cookies = {cookie.name: cookie.value for cookie in self.cookies}
 
         # do a few retries.
@@ -411,7 +424,7 @@ class Client(object):
 
     def _load_session(self):
         self.authenticated = False
-        
+
         if not self.cookies:
             self.cookies = cookielib.LWPCookieJar(filename=self.cookie_file)
         try:

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -46,6 +46,22 @@ class Authenticate(Command):
             sys.stderr.write('Unable to write authentication data: %s' % e)
             sys.exit(1)
 
+class Authorize(Command):
+    """Authorizes this device with Amazon Cloud Player."""
+    def add_options(self, parser):
+        parser.add_option('--devname', default=None,
+                          help='a user friendly name for this device')
+
+    def run(self):
+        if not self.client.authorized:
+            if self.client.authorize(self.options.devname):
+                print 'Device authorized successfully.'
+            else:
+                sys.stderr.write('Device authorization failed.\n')
+                sys.exit(1)
+        else:
+            sys.stderr.write('Device already authorized.')
+            sys.exit(1)
 
 class DownloadAll(Command):
     """Downloads all songs, all albums, all artists."""
@@ -319,6 +335,7 @@ class GetStreamURLs(Command):
 
 COMMANDS = {
     'authenticate': Authenticate(),
+    'authorize':Authorize(),
     'download-album': DownloadAlbum(),
     'download-all': DownloadAll(),
     'get-albums': GetAlbums(),

--- a/cloudplaya/main.py
+++ b/cloudplaya/main.py
@@ -46,6 +46,7 @@ class Authenticate(Command):
             sys.stderr.write('Unable to write authentication data: %s' % e)
             sys.exit(1)
 
+
 class Authorize(Command):
     """Authorizes this device with Amazon Cloud Player."""
     def add_options(self, parser):
@@ -62,6 +63,7 @@ class Authorize(Command):
         else:
             sys.stderr.write('Device already authorized.')
             sys.exit(1)
+
 
 class DownloadAll(Command):
     """Downloads all songs, all albums, all artists."""
@@ -335,7 +337,7 @@ class GetStreamURLs(Command):
 
 COMMANDS = {
     'authenticate': Authenticate(),
-    'authorize':Authorize(),
+    'authorize': Authorize(),
     'download-album': DownloadAlbum(),
     'download-all': DownloadAll(),
     'get-albums': GetAlbums(),


### PR DESCRIPTION
The attached changes re-enable access to the song URLs and allow cloudplaya to be registered as an authorized device with the Amazon Cloud Player service.
